### PR TITLE
README updates while trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,28 @@ There are multiple binary crates in this repository.
 1. Open terminal
 
     ```sh
-    $ export OPENOCD_ROOT=/where/you/installed/infineon/openocd
+    export OPENOCD_ROOT=/where/you/installed/infineon/openocd
 
     # The scripts path might be different depending on whether you
-    # have built and installed Infineon's openocd yourself or if
+    # have built and installed Infineons openocd yourself or if
     # have downloaded the pre-built Cypress toolset. This tutorial
     # assumes the latter.
-    $ ${OPENOCD_ROOT}/bin/openocd -s ${OPENOCD_ROOT}/scripts
+
+    ${OPENOCD_ROOT}/bin/openocd -s ${OPENOCD_ROOT}/scripts
     ```
 
 2. Open another terminal
 
     ```sh
-    $ rustup target add thumbv7em-none-eabihf
-    # On newer Ubuntu/Debian machines you may not need this, so
-    # ignore. `gdb-multiarch` on the newer OS takes care of this
-    # and setting this will actually throw an error. Instead,
-    # edit the file `.cargo/config.toml` and replace 
-    # runner = "rust-gdb -q -x openocd.gdb"
-    # with
-    # runner = "gdb-multiarch -q -x openocd.gdb"
-    $ export RUST_GDB=arm-none-eabi-gdb
-    $ cd psoc6-cm4-hello-world
-    $ cargo run --release
+    rustup target add thumbv7em-none-eabihf
+
+    # If you have another installation of GDB,
+    # e.g. `gdb-multiarch`, set
+    # `export RUST_GDB=gdb-multiarch`
+
+    export RUST_GDB=arm-none-eabi-gdb
+    cd psoc6-cm4-hello-world
+    cargo run --release
     ```
 
 ### To run a Cortex-M0+ binary
@@ -44,29 +43,28 @@ There are multiple binary crates in this repository.
 1. Open terminal
 
     ```sh
-    $ export OPENOCD_ROOT=/where/you/installed/infineon/openocd
+    export OPENOCD_ROOT=/where/you/installed/infineon/openocd
 
     # The scripts path might be different depending on whether you
-    # have built and installed Infineon's openocd yourself or if
+    # have built and installed Infineons openocd yourself or if
     # have downloaded the pre-built Cypress toolset. This tutorial
     # assumes the latter.
-    $ ${OPENOCD_ROOT}/bin/openocd -s ${OPENOCD_ROOT}/scripts
+
+    ${OPENOCD_ROOT}/bin/openocd -s ${OPENOCD_ROOT}/scripts
     ```
 
 2. Open another terminal
   
     ```sh
-    $ rustup target add thumbv6m-none-eabi
-    # On newer Ubuntu/Debian machines you may not need this, so
-    # ignore. `gdb-multiarch` on the newer OS takes care of this
-    # and setting this will actually throw an error. Instead,
-    # edit the file `.cargo/config.toml` and replace 
-    # runner = "rust-gdb -q -x openocd.gdb"
-    # with
-    # runner = "gdb-multiarch -q -x openocd.gdb"
-    $ export RUST_GDB=arm-none-eabi-gdb
-    $ cd psoc6-cm0-hello-world
-    $ cargo run --release
+    rustup target add thumbv6m-none-eabi
+
+    # If you have another installation of GDB,
+    # e.g. `gdb-multiarch`, set
+    # `export RUST_GDB=gdb-multiarch`
+
+    export RUST_GDB=arm-none-eabi-gdb
+    cd psoc6-cm0-hello-world
+    cargo run --release
     ```
 
 So if you want your code to run outside of the debugger, compile it for the


### PR DESCRIPTION
@jonathanpallant 

I tried and could only get to finish the run of first two hello-worlds.


- I have added notes within the commands and given them headings etc. 
- Noted that one is better off with Cypress 
- Noted that `export RUST_GDB=arm-none-eabi-gdb` may not work on newer Linux systems because we use `gdb-multiarch` which also means that we have to change `.cargo/config.toml` to use `gdb-multiarch` instead of `rust-gdb`
- `cd` into directories fix where there are no crate directories with `demo` in them
- There is no target `thumbv6m-none-eabihf` and I think you meant `thumbv6m-none-eabi` (Is this correct?)

I did not have access to push so for now using a fork but we can fix that later/tomorrow.